### PR TITLE
Read DST configuration value correctly

### DIFF
--- a/zendeskMakeAssignments.gs
+++ b/zendeskMakeAssignments.gs
@@ -543,7 +543,7 @@ function isWithinWorkingHours(startHour, endHour) {
 }
 
 function isDaylightSavingsTime() {
-  return PropertiesService.getScriptProperties().getProperty('isDaylightSavingsTime');
+  return 'true' === PropertiesService.getScriptProperties().getProperty('isDaylightSavingsTime');
 }
 
 function offsetFromUTC() {


### PR DESCRIPTION
Google stores all properties as strings so we must check against the string value

https://greenhouseio.atlassian.net/browse/OPS-859

To reproduce, hard code getCurrentUtcHour to return 14 and run using this spreadsheet https://docs.google.com/spreadsheets/d/1Aw4iIW4aZ60hTEKXhYDDfDrzsYB8I2vxGWUbXSrsmHQ/edit#gid=0

The original bug:
We would think 15 - 23 was the shift because DST was always on. So, at 14:00, those on the 14-22 shift were erroneously marked as not working.