### PR TITLE
Assign tickets by number of tickets an agent already has, and limit max number of tickets per agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ This should be the start and end of working hours in UTC and 24 hour notation se
 You'll need to convert from your local time zone into UTC time zone. For example, 9am - 5pm EST would be represented as `14-22` and 9:00AM - 5:00PM PST would be `17-1`.
 - __daylight savings time?:__ Determine if we should compensate for daylight savings time. If this flag is set incorrectly, all calculations will be off by one. Value should be `yes` or `no`. For an example converter, check out https://www.timeanddate.com/worldclock/converter.html?iso=20180116T140000&p1=179&p2=1440
 - __readonly:__ Determines if the script will actually assign tickets or not.
-- __max tickets per round__: Determines how many tickets each run of the ticket will assign.
+- __max tickets per agent__: Max number of tickets each agent should have at a time
+- __max tickets per round__: How many tickets to attempt to assign each time the script runs
 
 ## Debugging
 

--- a/configuration.csv
+++ b/configuration.csv
@@ -3,5 +3,6 @@ username,username@example.com
 token,your-token
 working hours,9-17,12-20
 daylight savings time,no
-max tickets per person, 10
+max tickets per round, 10
 readonly,true
+max tickets per agent, 5


### PR DESCRIPTION
So I can view the diff easier 

https://greenhouseio.atlassian.net/browse/OPS-891

Added method `fakeOpenTickets` which may be returned by `fetchOpenTickets` for easier testing